### PR TITLE
Feature/rpc retry policy

### DIFF
--- a/calculator/pom.xml
+++ b/calculator/pom.xml
@@ -23,6 +23,7 @@
         <model-mapper-version>2.3.7</model-mapper-version>
         <grpc-protobuf-version>1.36.0</grpc-protobuf-version>
         <tomcat-annotation-api-version>6.0.53</tomcat-annotation-api-version>
+        <guava.version>30.1-jre</guava.version>
     </properties>
 
     <dependencies>
@@ -114,6 +115,11 @@
             <version>${tomcat-annotation-api-version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency> <!-- Needed for gRPC ServiceConfig setup -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.market.banica</groupId>
@@ -124,7 +130,6 @@
             <groupId>com.market.banica</groupId>
             <artifactId>common</artifactId>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/calculator/pom.xml
+++ b/calculator/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>protobuf-messages</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.market.banica</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/calculator/src/main/java/com/market/banica/calculator/exception/GlobalExceptionHandler.java
+++ b/calculator/src/main/java/com/market/banica/calculator/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.market.banica.calculator.exception;
 
 import com.market.banica.calculator.exception.exceptions.BadResponseException;
 import com.market.banica.calculator.exception.exceptions.FeatureNotSupportedException;
-import com.market.banica.calculator.service.grpcService.AuroraClientSideService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/calculator/src/main/java/com/market/banica/calculator/service/CalculatorServiceImpl.java
+++ b/calculator/src/main/java/com/market/banica/calculator/service/CalculatorServiceImpl.java
@@ -3,7 +3,7 @@ package com.market.banica.calculator.service;
 import com.market.banica.calculator.dto.RecipeDTO;
 import com.market.banica.calculator.exception.exceptions.FeatureNotSupportedException;
 import com.market.banica.calculator.service.contract.CalculatorService;
-import com.market.banica.calculator.service.grpcService.AuroraClientSideService;
+import com.market.banica.calculator.service.grpc.AuroraClientSideService;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/calculator/src/main/java/com/market/banica/calculator/service/grpc/AuroraClientSideService.java
+++ b/calculator/src/main/java/com/market/banica/calculator/service/grpc/AuroraClientSideService.java
@@ -1,9 +1,10 @@
-package com.market.banica.calculator.service.grpcService;
+package com.market.banica.calculator.service.grpc;
 
 
 import com.aurora.Aurora;
 import com.aurora.AuroraServiceGrpc;
 import com.market.banica.calculator.exception.exceptions.BadResponseException;
+import com.market.banica.common.ChannelRPCConfig;
 import com.orderbook.ItemOrderBookResponse;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -25,6 +26,7 @@ import javax.annotation.PreDestroy;
 
 @Service
 public class AuroraClientSideService {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AuroraClientSideService.class);
 
     /**
@@ -44,7 +46,10 @@ public class AuroraClientSideService {
 
         managedChannel = ManagedChannelBuilder.forAddress(host, port)
                 .usePlaintext()
+                .defaultServiceConfig(ChannelRPCConfig.getRetryingServiceConfig())
+                .enableRetry()
                 .build();
+
     }
 
 
@@ -54,7 +59,7 @@ public class AuroraClientSideService {
         LOGGER.debug("Building blocking stub");
         AuroraServiceGrpc.AuroraServiceBlockingStub blockingStub = getBlockingStub();
 
-        LOGGER.debug("Building request with parameters " + message);
+        LOGGER.debug("Building request with parameters {}", message);
         Aurora.AuroraRequest request = Aurora.AuroraRequest.newBuilder()
                 .setClientId(clientId)
                 .setTopic(message)
@@ -64,7 +69,7 @@ public class AuroraClientSideService {
 
         Aurora.AuroraResponse auroraResponse = blockingStub.request(request);
 
-        if (auroraResponse.hasItemOrderBookResponse()){
+        if (auroraResponse.hasItemOrderBookResponse()) {
             return auroraResponse.getItemOrderBookResponse();
         }
 

--- a/calculator/src/main/java/com/market/banica/calculator/service/grpc/AuroraClientSideService.java
+++ b/calculator/src/main/java/com/market/banica/calculator/service/grpc/AuroraClientSideService.java
@@ -46,7 +46,7 @@ public class AuroraClientSideService {
 
         managedChannel = ManagedChannelBuilder.forAddress(host, port)
                 .usePlaintext()
-                .defaultServiceConfig(ChannelRPCConfig.getRetryingServiceConfig())
+                .defaultServiceConfig(ChannelRPCConfig.getInstance().getServiceConfig())
                 .enableRetry()
                 .build();
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>market-root</artifactId>
+        <groupId>com.market.banica</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>common</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/common/src/main/java/com/market/banica/common/ChannelRPCConfig.java
+++ b/common/src/main/java/com/market/banica/common/ChannelRPCConfig.java
@@ -10,18 +10,31 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ChannelRPCConfig {
 
-    private ChannelRPCConfig() {
-    }
+    private static ChannelRPCConfig instance;
+    private final Map<String, ?> serviceConfig;
 
-    public static Map<String, ?> getRetryingServiceConfig() {
-        return new Gson().fromJson(
+    private ChannelRPCConfig() {
+        serviceConfig = new Gson().fromJson(
                 new JsonReader(
                         new InputStreamReader(
                                 ChannelRPCConfig.class.getResourceAsStream(
-                                        "retrying_service_config.json"),
+                                        "/retrying_service_config.json"),
                                 UTF_8)),
                 Map.class);
     }
 
+    public static ChannelRPCConfig getInstance() {
+
+        if (instance == null) {
+            instance = new ChannelRPCConfig();
+        }
+
+        return instance;
+
+    }
+
+    public Map<String, ?> getServiceConfig() {
+        return serviceConfig;
+    }
 
 }

--- a/common/src/main/java/com/market/banica/common/ChannelRPCConfig.java
+++ b/common/src/main/java/com/market/banica/common/ChannelRPCConfig.java
@@ -1,0 +1,27 @@
+package com.market.banica.common;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+
+import java.io.InputStreamReader;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class ChannelRPCConfig {
+
+    private ChannelRPCConfig() {
+    }
+
+    public static Map<String, ?> getRetryingServiceConfig() {
+        return new Gson().fromJson(
+                new JsonReader(
+                        new InputStreamReader(
+                                ChannelRPCConfig.class.getResourceAsStream(
+                                        "retrying_service_config.json"),
+                                UTF_8)),
+                Map.class);
+    }
+
+
+}

--- a/common/src/main/resources/retrying_service_config.json
+++ b/common/src/main/resources/retrying_service_config.json
@@ -1,0 +1,29 @@
+{
+  "methodConfig": [
+    {
+      "name": [
+        {
+          "service": "aurora.AuroraService"
+        },
+        {
+          "service": "market.MarketService"
+        },
+        {
+          "service": "orderbook.OrderBookService"
+        }
+      ],
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.5s",
+        "maxBackoff": "30s",
+        "backoffMultiplier": 2,
+        "retryableStatusCodes": [
+          "UNAVAILABLE",
+          "NOT_FOUND",
+          "DEADLINE_EXCEEDED",
+          "DATA_LOSS"
+        ]
+      }
+    }
+  ]
+}

--- a/order-book/pom.xml
+++ b/order-book/pom.xml
@@ -3,12 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.market.banica</groupId>
         <artifactId>market-root</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <groupId>com.market.banica</groupId>
+
     <artifactId>order-book</artifactId>
     <version>1.0-SNAPSHOT</version>
 
@@ -19,7 +20,6 @@
         <grpc.protobuf.version>1.36.0</grpc.protobuf.version>
         <grpc.stub.version>1.36.0</grpc.stub.version>
         <apache.annotations.version>6.0.53</apache.annotations.version>
-<!--        <lombok.version>1.18.16</lombok.version>-->
         <log4j.version>2.7</log4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -68,6 +68,11 @@
         <dependency> <!--Proto files -->
             <groupId>com.market.banica</groupId>
             <artifactId>protobuf-messages</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.market.banica</groupId>
+            <artifactId>common</artifactId>
         </dependency>
 
         <dependency>

--- a/order-book/pom.xml
+++ b/order-book/pom.xml
@@ -21,6 +21,7 @@
         <grpc.stub.version>1.36.0</grpc.stub.version>
         <apache.annotations.version>6.0.53</apache.annotations.version>
         <log4j.version>2.7</log4j.version>
+        <guava.version>30.1-jre</guava.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -85,6 +86,12 @@
             <artifactId>annotations-api</artifactId>
             <version>${apache.annotations.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency> <!-- Needed for gRPC ServiceConfig setup -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
 
         <!--  Utility dependencies  -->

--- a/order-book/src/main/java/com/market/banica/order/book/MarketDataClient.java
+++ b/order-book/src/main/java/com/market/banica/order/book/MarketDataClient.java
@@ -1,10 +1,9 @@
 package com.market.banica.order.book;
 
-import com.market.MarketServiceGrpc;
 import com.market.MarketDataRequest;
+import com.market.MarketServiceGrpc;
 import com.market.TickResponse;
-
-import io.grpc.ConnectivityState;
+import com.market.banica.common.ChannelRPCConfig;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
@@ -21,10 +20,6 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class MarketDataClient {
 
-    private static final int FAILED_ATTEMPTS = 0;
-    private static final long DEFAULT_WAIT_TIME_IN_MILLI = 1000;
-    public static final int FAILED_ATTEMPTS_LIMIT = 11;
-
     private final ItemMarket itemMarket;
     private final ManagedChannel managedChannel;
     private static final Logger LOGGER = LogManager.getLogger(MarketDataClient.class);
@@ -32,13 +27,15 @@ public class MarketDataClient {
     @Autowired
     MarketDataClient(ItemMarket itemMarket,
                      @Value("${aurora.server.host}") final String host,
-                     @Value("${aurora.server.port}") final int port) throws InterruptedException {
+                     @Value("${aurora.server.port}") final int port) {
+
         managedChannel = ManagedChannelBuilder.forAddress(host, port)
                 .usePlaintext()
+                .defaultServiceConfig(ChannelRPCConfig.getRetryingServiceConfig())
+                .enableRetry()
                 .build();
-        this.itemMarket = itemMarket;
 
-        tryReconnect(managedChannel);
+        this.itemMarket = itemMarket;
 
     }
 
@@ -82,31 +79,4 @@ public class MarketDataClient {
         LOGGER.info("Server is terminated!");
     }
 
-    private void tryReconnect(ManagedChannel channel) {
-        int failedAttempts = FAILED_ATTEMPTS;
-        long timeToWait = DEFAULT_WAIT_TIME_IN_MILLI;
-
-        while (!managedChannel.getState(true).equals(ConnectivityState.READY)) {
-            try {
-                Thread.sleep(timeToWait);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            if (failedAttempts < FAILED_ATTEMPTS_LIMIT) {
-
-                failedAttempts++;
-                timeToWait *= 2;
-
-                LOGGER.info("Attempt number : " + failedAttempts + " failed to recconnect!");
-                LOGGER.info("Next attempt will execute in : " + timeToWait + " milliseconds");
-            }else{
-                failedAttempts++;
-                LOGGER.info("Attempts to recconnect : " + failedAttempts);
-                LOGGER.info("Next attempt will execute in : " + timeToWait + " milliseconds");
-            }
-        }
-        managedChannel.notifyWhenStateChanged(ConnectivityState.READY, () -> {
-            tryReconnect(managedChannel);
-        });
-    }
 }

--- a/order-book/src/main/java/com/market/banica/order/book/MarketDataClient.java
+++ b/order-book/src/main/java/com/market/banica/order/book/MarketDataClient.java
@@ -31,7 +31,7 @@ public class MarketDataClient {
 
         managedChannel = ManagedChannelBuilder.forAddress(host, port)
                 .usePlaintext()
-                .defaultServiceConfig(ChannelRPCConfig.getRetryingServiceConfig())
+                .defaultServiceConfig(ChannelRPCConfig.getInstance().getServiceConfig())
                 .enableRetry()
                 .build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
         <grpc-services.version>1.29.0</grpc-services.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <lombok.version>1.18.16</lombok.version>
-        <prtobuf-messages.version>1.0-SNAPSHOT</prtobuf-messages.version>
+        <protobuf-messages.version>1.0-SNAPSHOT</protobuf-messages.version>
+        <common.version>1.0-SNAPSHOT</common.version>
     </properties>
 
     <modules>
@@ -34,6 +35,7 @@
         <module>persister</module>
         <module>order-book</module>
         <module>calculator</module>
+        <module>common</module>
     </modules>
 
     <dependencyManagement>
@@ -65,7 +67,13 @@
             <dependency>
                 <groupId>com.market.banica</groupId>
                 <artifactId>protobuf-messages</artifactId>
-                <version>${prtobuf-messages.version}</version>
+                <version>${protobuf-messages.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.market.banica</groupId>
+                <artifactId>common</artifactId>
+                <version>${common.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/protobuf-messages/src/main/proto/aurora.proto
+++ b/protobuf-messages/src/main/proto/aurora.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package aurora;
+
 option java_package = "com.aurora";
 
 import "market.proto";
@@ -14,9 +16,9 @@ message AuroraRequest{
 message AuroraResponse{
 
   oneof responses{
-    TickResponse tickResponse = 2;
-    TradeActionProductResponse tradeActionProductResponse = 1;
-    ItemOrderBookResponse itemOrderBookResponse = 3;
+    market.TickResponse tickResponse = 2;
+    market.TradeActionProductResponse tradeActionProductResponse = 1;
+    orderbook.ItemOrderBookResponse itemOrderBookResponse = 3;
   }
 
 }

--- a/protobuf-messages/src/main/proto/market.proto
+++ b/protobuf-messages/src/main/proto/market.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package market;
+
 option java_package = "com.market";
 option java_multiple_files = true;
 
@@ -37,12 +39,14 @@ message BuyGoodRequest{
   double price = 3;
   Origin origin = 4;
 }
+
 message SellGoodRequest{
   string goodName = 1;
   int64 quantity = 2;
   double price = 3;
   Origin origin = 4;
 }
+
 message TradeActionProductResponse{
   string message = 1 ;
 }

--- a/protobuf-messages/src/main/proto/orderbook.proto
+++ b/protobuf-messages/src/main/proto/orderbook.proto
@@ -1,6 +1,8 @@
-    syntax = "proto3";
+syntax = "proto3";
 
-    option java_package = "com.orderbook";
+package orderbook;
+
+option java_package = "com.orderbook";
 
 option java_multiple_files = true;
 


### PR DESCRIPTION
Adding RPC retry policy and removing Valentin's reconnection policy (with his consent, of course) due to gRPC having internal reconnection exponential back off policy.
Adding guava with higher version to calculator and order-book as it is needed for using gRPC ManagedChannel serviceConfig.
New retry policy uses a JSON config and a reader singleton class added in a new module named "common".