### PR TITLE
RBSFXIRJTP-230 - Fix snapshot persistence

### DIFF
--- a/market-generator/src/main/java/com/market/banica/generator/model/MarketTick.java
+++ b/market-generator/src/main/java/com/market/banica/generator/model/MarketTick.java
@@ -1,6 +1,7 @@
 package com.market.banica.generator.model;
 
 import com.market.Origin;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -11,7 +12,8 @@ import java.util.Locale;
 @Getter
 @ToString
 @NoArgsConstructor
-public class MarketTick {
+@EqualsAndHashCode
+public class MarketTick implements Comparable<MarketTick> {
 
     private static Origin origin;
     private String good;
@@ -38,6 +40,11 @@ public class MarketTick {
                 break;
             }
         }
+    }
+
+    @Override
+    public int compareTo(MarketTick other) {
+        return Long.compare(this.timestamp, other.timestamp);
     }
 
 }

--- a/market-generator/src/main/java/com/market/banica/generator/service/MarketStateImpl.java
+++ b/market-generator/src/main/java/com/market/banica/generator/service/MarketStateImpl.java
@@ -14,7 +14,6 @@ import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +58,7 @@ public class MarketStateImpl implements MarketState {
                 marketStateLock.writeLock().lock();
                 String good = marketTick.getGood();
                 if (!marketState.containsKey(good)) {
-                    marketState.put(good, new HashSet<>());
+                    marketState.put(good, new TreeSet<>());
                 }
                 marketState.get(good).add(marketTick);
                 subscriptionManager.notifySubscribers(convertMarketTickToTickResponse(marketTick));
@@ -109,7 +108,7 @@ public class MarketStateImpl implements MarketState {
     private TickResponse convertMarketTickToTickResponse(MarketTick marketTick) {
         return TickResponse.newBuilder()
                 .setOrigin(MarketTick.getOrigin())
-                .setTimestamp(System.currentTimeMillis())
+                .setTimestamp(marketTick.getTimestamp())
                 .setGoodName(marketTick.getGood())
                 .setPrice(marketTick.getPrice())
                 .setQuantity(marketTick.getQuantity())

--- a/market-generator/src/main/java/com/market/banica/generator/util/SnapshotPersistence.java
+++ b/market-generator/src/main/java/com/market/banica/generator/util/SnapshotPersistence.java
@@ -67,7 +67,7 @@ public class SnapshotPersistence {
     private static void initKryo() {
 
         kryoHandle.register(java.util.concurrent.ConcurrentHashMap.class);
-        kryoHandle.register(java.util.HashSet.class);
+        kryoHandle.register(java.util.TreeSet.class);
         kryoHandle.register(MarketTick.class);
 
     }


### PR DESCRIPTION
- Updated SnapshotPersistence to use TreeSet to store ticks in ascending order according to timestamp.
- Made a quick fix to MarketStateImpl to use the timestamp of the actual tick and not System.currentTime.