### PR TITLE
Market service - update snapshot persistence.

### DIFF
--- a/market-generator/src/main/java/com/market/banica/generator/service/MarketState.java
+++ b/market-generator/src/main/java/com/market/banica/generator/service/MarketState.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface MarketState {
 
-    void addTickToMarketState(MarketTick marketTick);
+    void addTickToMarketSnapshot(MarketTick marketTick);
 
     List<TickResponse> generateMarketTicks(String good);
 

--- a/market-generator/src/main/java/com/market/banica/generator/service/TickGeneratorImpl.java
+++ b/market-generator/src/main/java/com/market/banica/generator/service/TickGeneratorImpl.java
@@ -86,7 +86,7 @@ public class TickGeneratorImpl implements TickGenerator {
     @Override
     public void executeTickTask(MarketTick marketTick, TickTask nextTick, long delay) {
 
-        marketState.addTickToMarketState(marketTick);
+        marketState.addTickToMarketSnapshot(marketTick);
 
         ScheduledFuture<?> taskScheduledFuture = tickScheduler.schedule(nextTick, delay, TimeUnit.SECONDS);
 

--- a/market-generator/src/main/java/com/market/banica/generator/util/SnapshotPersistence.java
+++ b/market-generator/src/main/java/com/market/banica/generator/util/SnapshotPersistence.java
@@ -12,54 +12,103 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class SnapshotPersistence {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotPersistence.class);
 
-    private final String databaseFileName;
+    private final String stateFileName;
+    private final String snapshotFileName;
 
     private final Kryo kryoHandle = new Kryo();
 
-    public SnapshotPersistence(String fileName) {
+    public SnapshotPersistence(String stateFileName, String snapshotFileName) {
         initKryo();
-        this.databaseFileName = fileName;
+        this.stateFileName = stateFileName;
+        this.snapshotFileName = snapshotFileName;
     }
 
-    public void persistTicks(Map<String, Set<MarketTick>> newTicks) throws IOException {
+    public void persistMarketState(Map<String, Set<MarketTick>> marketState, Queue<MarketTick> marketSnapshot) throws IOException {
 
-        Output output = new Output(new FileOutputStream(ApplicationDirectoryUtil.getConfigFile(databaseFileName)));
-        kryoHandle.writeClassAndObject(output, newTicks);
+        while (!marketSnapshot.isEmpty()) {
+            MarketTick currentTick = marketSnapshot.poll();
+            String good = currentTick.getGood();
+            marketState.putIfAbsent(good, new TreeSet<>());
+            marketState.get(good).add(currentTick);
+        }
+
+        Output output = new Output(new FileOutputStream(ApplicationDirectoryUtil.getConfigFile(stateFileName)));
+        kryoHandle.writeClassAndObject(output, marketState);
         output.close();
-        LOGGER.info("Persisting snapshot database!");
+        LOGGER.info("Persisting market state!");
+
+        persistMarketSnapshot(marketSnapshot);
+
+    }
+
+    public void persistMarketSnapshot(Queue<MarketTick> marketSnapshot) throws IOException {
+
+        Output output = new Output(new FileOutputStream(ApplicationDirectoryUtil.getConfigFile(snapshotFileName)));
+        kryoHandle.writeClassAndObject(output, marketSnapshot);
+        output.close();
+        LOGGER.debug("Persisting market snapshot!");
 
     }
 
     @SuppressWarnings({"unchecked"})
-    public Map<String, Set<MarketTick>> loadPersistedSnapshot() throws IOException {
+    public Map<String, Set<MarketTick>> loadMarketState() throws IOException {
 
-        Map<String, Set<MarketTick>> loadedMarketTicks = new ConcurrentHashMap<>();
+        Map<String, Set<MarketTick>> loadedMarketStateTicks = new ConcurrentHashMap<>();
 
-        if (!ApplicationDirectoryUtil.doesFileExist(databaseFileName)) {
+        if (!ApplicationDirectoryUtil.doesFileExist(stateFileName)) {
 
-            LOGGER.info("Creating \"{}\" file!", databaseFileName);
-            ApplicationDirectoryUtil.getConfigFile(databaseFileName);
+            LOGGER.info("Creating \"{}\" file!", stateFileName);
+            ApplicationDirectoryUtil.getConfigFile(stateFileName);
 
-        } else if (ApplicationDirectoryUtil.getConfigFile(databaseFileName).length() == 0) {
+        } else if (ApplicationDirectoryUtil.getConfigFile(stateFileName).length() == 0) {
 
-            LOGGER.info("File \"{}\" is empty, no ticks were loaded!", databaseFileName);
+            LOGGER.info("File \"{}\" is empty, no ticks were loaded!", stateFileName);
 
         } else {
 
-            Input input = new Input(new FileInputStream(ApplicationDirectoryUtil.getConfigFile(databaseFileName)));
-            loadedMarketTicks = (Map<String, Set<MarketTick>>) kryoHandle.readClassAndObject(input);
+            Input input = new Input(new FileInputStream(ApplicationDirectoryUtil.getConfigFile(stateFileName)));
+            loadedMarketStateTicks = (Map<String, Set<MarketTick>>) kryoHandle.readClassAndObject(input);
+            input.close();
+            LOGGER.info("Loaded market state ticks!");
+
+        }
+        return loadedMarketStateTicks;
+
+    }
+
+    @SuppressWarnings({"unchecked"})
+    public Queue<MarketTick> loadMarketSnapshot() throws IOException {
+
+        Queue<MarketTick> loadedSnapshotTicks = new LinkedBlockingQueue<>();
+
+        if (!ApplicationDirectoryUtil.doesFileExist(snapshotFileName)) {
+
+            LOGGER.info("Creating \"{}\" file!", snapshotFileName);
+            ApplicationDirectoryUtil.getConfigFile(snapshotFileName);
+
+        } else if (ApplicationDirectoryUtil.getConfigFile(snapshotFileName).length() == 0) {
+
+            LOGGER.info("File \"{}\" is empty, no ticks were loaded!", snapshotFileName);
+
+        } else {
+
+            Input input = new Input(new FileInputStream(ApplicationDirectoryUtil.getConfigFile(snapshotFileName)));
+            loadedSnapshotTicks = (Queue<MarketTick>) kryoHandle.readClassAndObject(input);
             input.close();
             LOGGER.info("Loaded snapshot database!");
 
         }
-        return loadedMarketTicks;
+        return loadedSnapshotTicks;
 
     }
 
@@ -67,6 +116,7 @@ public class SnapshotPersistence {
 
         kryoHandle.register(java.util.concurrent.ConcurrentHashMap.class);
         kryoHandle.register(java.util.TreeSet.class);
+        kryoHandle.register(java.util.concurrent.LinkedBlockingQueue.class);
         kryoHandle.register(MarketTick.class);
 
     }

--- a/market-generator/src/main/resources/application.properties
+++ b/market-generator/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 application.executor.pool.size=4
 
-tick.database.file.name=${market.name}-tickDatabase.dat
+tick.market.state.file.name=${market.name}-marketState.dat
+tick.market.snapshot.file.name=${market.name}-marketSnapshot.dat
 market.properties.file.name=${market.name}-market.properties
 market.name=${market:europe}
 server.port=${port:8020}

--- a/market-generator/src/test/java/com/market/banica/generator/service/MarketStateImplTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/service/MarketStateImplTest.java
@@ -6,6 +6,7 @@ import com.market.TickResponse;
 import com.market.banica.common.util.ApplicationDirectoryUtil;
 import com.market.banica.generator.model.MarketTick;
 import com.market.banica.generator.util.PersistScheduler;
+import com.market.banica.generator.util.SnapshotPersistence;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,8 +21,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -35,32 +38,42 @@ import static org.mockito.Mockito.when;
 class MarketStateImplTest {
 
     private static final String GOOD_BANICA = "banica";
+    private static final String GOOD_EGGS = "eggs";
 
     private static final MarketSubscriptionManager subscriptionManager = mock(MarketSubscriptionManager.class);
     @SuppressWarnings("unchecked")
     private static final Map<String, Set<MarketTick>> marketStateMap = mock(Map.class);
+    @SuppressWarnings("unchecked")
+    private static final Queue<MarketTick> marketSnapshot = mock(Queue.class);
     private static final PersistScheduler persistScheduler = mock(PersistScheduler.class);
+    private static final SnapshotPersistence snapshotPersistence = mock(SnapshotPersistence.class);
 
-    private static final String fileName = "test-tickDatabase.dat";
+    private static final String stateFileName = "test-marketState.dat";
+    private static final String snapshotFileName = "test-marketSnapshot.dat";
 
     private static MarketState marketState;
 
     @BeforeAll
     static void beforeAll() throws IOException {
 
-        marketState = new MarketStateImpl(fileName, subscriptionManager);
+        marketState = new MarketStateImpl(stateFileName, snapshotFileName, subscriptionManager);
         ReflectionTestUtils.setField(marketState, "marketState", marketStateMap);
+        ReflectionTestUtils.setField(marketState, "marketSnapshot", marketSnapshot);
         ReflectionTestUtils.setField(marketState, "executorService", MoreExecutors.newDirectExecutorService());
         ReflectionTestUtils.setField(marketState, "persistScheduler", persistScheduler);
+        ReflectionTestUtils.setField(marketState, "snapshotPersistence", snapshotPersistence);
         MarketTick.setOrigin("europe");
+
 
     }
 
     @AfterAll
     static void afterAll() throws IOException {
 
-        File testTickDB = ApplicationDirectoryUtil.getConfigFile(fileName);
-        testTickDB.deleteOnExit();
+        File testStateFile = ApplicationDirectoryUtil.getConfigFile(stateFileName);
+        File testSnapshotFile = ApplicationDirectoryUtil.getConfigFile(snapshotFileName);
+        testStateFile.deleteOnExit();
+        testSnapshotFile.deleteOnExit();
 
     }
 
@@ -70,12 +83,13 @@ class MarketStateImplTest {
 
         reset(subscriptionManager);
         reset(marketStateMap);
+        reset(marketSnapshot);
         reset(persistScheduler);
 
     }
 
     @Test
-    void addTickToMarketState_CratesNewSet() {
+    void addTickToMarketSnapshot() throws IOException {
 
         MarketTick marketTick = mock(MarketTick.class);
         TreeSet<MarketTick> emptySet = new TreeSet<>();
@@ -87,34 +101,11 @@ class MarketStateImplTest {
         when(marketStateMap.get(GOOD_BANICA)).thenReturn(emptySetSpy);
 
 
-        marketState.addTickToMarketState(marketTick);
+        marketState.addTickToMarketSnapshot(marketTick);
 
 
-        verify(marketStateMap, times(1)).containsKey(GOOD_BANICA);
-        verify(marketStateMap, times(1)).put(GOOD_BANICA, new TreeSet<>());
-        verify(emptySetSpy, times(1)).add(marketTick);
-        verify(subscriptionManager, times(1))
-                .notifySubscribers(convertMarketTickToTickResponse(marketTick));
-
-    }
-
-    @Test
-    void addTickToMarketState_UsesOldSet() {
-
-        MarketTick marketTick = mock(MarketTick.class);
-        TreeSet<MarketTick> oldSet = new TreeSet<>();
-        TreeSet<MarketTick> oldSetSpy = spy(oldSet);
-
-        when(marketTick.getGood()).thenReturn(GOOD_BANICA);
-        when(marketStateMap.containsKey(GOOD_BANICA)).thenReturn(true);
-        when(marketStateMap.get(GOOD_BANICA)).thenReturn(oldSetSpy);
-
-
-        marketState.addTickToMarketState(marketTick);
-
-
-        verify(marketStateMap, times(1)).containsKey(GOOD_BANICA);
-        verify(oldSetSpy, times(1)).add(marketTick);
+        verify(marketSnapshot, times(1)).add(marketTick);
+        verify(snapshotPersistence, times(1)).persistMarketSnapshot(marketSnapshot);
         verify(subscriptionManager, times(1))
                 .notifySubscribers(convertMarketTickToTickResponse(marketTick));
 
@@ -123,12 +114,19 @@ class MarketStateImplTest {
     @Test
     void generateMarketTicks_WhenGoodDoesNotExist() {
 
-        when(marketStateMap.containsKey(GOOD_BANICA)).thenReturn(false);
+        MarketTick marketTick1 = new MarketTick(GOOD_EGGS, 1, 1, 1);
+        MarketTick marketTick2 = new MarketTick(GOOD_EGGS, 2, 2, 2);
+
+        when(marketStateMap.getOrDefault(GOOD_BANICA, new TreeSet<>())).thenReturn(new TreeSet<>());
+        when(marketSnapshot.stream()).thenReturn(Stream.of(marketTick1, marketTick2));
+
 
         List<TickResponse> result = marketState.generateMarketTicks(GOOD_BANICA);
 
+
         assertEquals(Collections.emptyList(), result);
-        verify(marketStateMap, times(1)).containsKey(GOOD_BANICA);
+        verify(marketStateMap, times(1)).getOrDefault(GOOD_BANICA, new TreeSet<>());
+        verify(marketSnapshot, times(1)).stream();
 
     }
 
@@ -137,21 +135,26 @@ class MarketStateImplTest {
 
         MarketTick marketTick1 = new MarketTick(GOOD_BANICA, 1, 1, 1);
         MarketTick marketTick2 = new MarketTick(GOOD_BANICA, 2, 2, 2);
+        MarketTick marketTick3 = new MarketTick(GOOD_EGGS, 3, 3, 3);
+        MarketTick marketTick4 = new MarketTick(GOOD_BANICA, 4, 4, 4);
 
         Set<MarketTick> marketTicks = new TreeSet<>(Arrays.asList(marketTick1, marketTick2));
 
-        when(marketStateMap.containsKey(GOOD_BANICA)).thenReturn(true);
-        when(marketStateMap.get(GOOD_BANICA)).thenReturn(marketTicks);
+        when(marketStateMap.getOrDefault(GOOD_BANICA, new TreeSet<>()))
+                .thenReturn(marketTicks);
+        when(marketSnapshot.stream()).thenReturn(Stream.of(marketTick3, marketTick4));
+
         List<TickResponse> actual = Arrays.asList(convertMarketTickToTickResponse(marketTick1),
-                convertMarketTickToTickResponse(marketTick2));
+                convertMarketTickToTickResponse(marketTick2),
+                convertMarketTickToTickResponse(marketTick4));
 
 
         List<TickResponse> result = marketState.generateMarketTicks(GOOD_BANICA);
 
 
         assertEquals(actual, result);
-        verify(marketStateMap, times(1)).containsKey(GOOD_BANICA);
-        verify(marketStateMap, times(1)).get(GOOD_BANICA);
+        verify(marketStateMap, times(1)).getOrDefault(GOOD_BANICA, new TreeSet<>());
+        verify(marketSnapshot, times(1)).stream();
 
     }
 

--- a/market-generator/src/test/java/com/market/banica/generator/service/TickGeneratorImplTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/service/TickGeneratorImplTest.java
@@ -197,7 +197,7 @@ class TickGeneratorImplTest {
         tickGenerator.executeTickTask(marketTick, tickTask, delay);
 
 
-        verify(marketState, times(1)).addTickToMarketState(marketTick);
+        verify(marketState, times(1)).addTickToMarketSnapshot(marketTick);
         verify(tickScheduler, times(1)).schedule(tickTask, delay, TimeUnit.SECONDS);
         verify(tickTasks, times(1)).put(GOOD_BANICA, taskScheduledFuture);
 

--- a/market-generator/src/test/java/com/market/banica/generator/task/SnapshotPersistenceTaskTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/task/SnapshotPersistenceTaskTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -23,17 +23,20 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SnapshotPersistenceTaskTest {
 
-    private static final ReadWriteLock marketStateLock = mock(ReadWriteLock.class);
+    private static final ReadWriteLock marketDataLock = mock(ReadWriteLock.class);
     private static final SnapshotPersistence snapshotPersistence = mock(SnapshotPersistence.class);
     @SuppressWarnings("unchecked")
-    private static final Map<String, Set<MarketTick>> newTicks = mock(Map.class);
+    private static final Map<String, Set<MarketTick>> marketState = mock(Map.class);
+    @SuppressWarnings("unchecked")
+    private static final Queue<MarketTick> marketSnapshot = mock(Queue.class);
 
     private static SnapshotPersistenceTask snapshotPersistenceTask;
 
     @BeforeAll
     static void beforeAll() {
 
-        snapshotPersistenceTask = new SnapshotPersistenceTask(marketStateLock, snapshotPersistence, newTicks);
+        snapshotPersistenceTask = new SnapshotPersistenceTask(marketDataLock,
+                snapshotPersistence, marketState, marketSnapshot);
 
     }
 
@@ -41,12 +44,12 @@ class SnapshotPersistenceTaskTest {
     void run() throws IOException {
 
         Lock newTicksReadLock = mock(ReentrantReadWriteLock.ReadLock.class);
-        when(marketStateLock.readLock()).thenReturn(newTicksReadLock);
+        when(marketDataLock.readLock()).thenReturn(newTicksReadLock);
 
         snapshotPersistenceTask.run();
 
         verify(newTicksReadLock, times(1)).lock();
-        verify(snapshotPersistence, times(1)).persistTicks(newTicks);
+        verify(snapshotPersistence, times(1)).persistMarketState(marketState, marketSnapshot);
         verify(newTicksReadLock, times(1)).unlock();
 
     }

--- a/market-generator/src/test/java/com/market/banica/generator/util/PersistSchedulerTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/util/PersistSchedulerTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,9 @@ class PersistSchedulerTest {
     private static final ReadWriteLock marketStateLock = mock(ReadWriteLock.class);
     private static final SnapshotPersistence snapshotPersistence = mock(SnapshotPersistence.class);
     @SuppressWarnings("unchecked")
-    private static final Map<String, Set<MarketTick>> newTicks = mock(Map.class);
+    private static final Map<String, Set<MarketTick>> marketState = mock(Map.class);
+    @SuppressWarnings("unchecked")
+    private static final Queue<MarketTick> marketSnapshot = mock(Queue.class);
     private static final SnapshotPersistenceTask currentSnapshotPersistenceTask = mock(SnapshotPersistenceTask.class);
 
     private static PersistScheduler persistScheduler;
@@ -38,7 +41,7 @@ class PersistSchedulerTest {
     @BeforeAll
     static void beforeAll() {
 
-        persistScheduler = new PersistScheduler(marketStateLock, snapshotPersistence, newTicks);
+        persistScheduler = new PersistScheduler(marketStateLock, snapshotPersistence, marketState, marketSnapshot);
         ReflectionTestUtils.setField(persistScheduler, "persistTimer", persistTimer);
         ReflectionTestUtils.setField(persistScheduler, "currentSnapshotPersistenceTask",
                 currentSnapshotPersistenceTask);
@@ -52,7 +55,8 @@ class PersistSchedulerTest {
         reset(persistTimer);
         reset(marketStateLock);
         reset(snapshotPersistence);
-        reset(newTicks);
+        reset(marketState);
+        reset(marketSnapshot);
         reset(currentSnapshotPersistenceTask);
 
     }
@@ -117,7 +121,7 @@ class PersistSchedulerTest {
         SnapshotPersistenceTask newPersistenceTask = (SnapshotPersistenceTask) ReflectionTestUtils
                 .getField(persistScheduler, "currentSnapshotPersistenceTask");
 
-        assertEquals(new SnapshotPersistenceTask(marketStateLock, snapshotPersistence, newTicks)
+        assertEquals(new SnapshotPersistenceTask(marketStateLock, snapshotPersistence, marketState, marketSnapshot)
                 , newPersistenceTask);
 
         verify(persistTimer).scheduleAtFixedRate(newPersistenceTask,

--- a/market-generator/src/test/java/com/market/banica/generator/util/SnapshotPersistenceTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/util/SnapshotPersistenceTest.java
@@ -1,7 +1,6 @@
 package com.market.banica.generator.util;
 
 import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.market.banica.common.util.ApplicationDirectoryUtil;
 import com.market.banica.generator.model.MarketTick;
@@ -13,13 +12,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,13 +30,15 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SnapshotPersistenceTest {
 
     private static final Kryo kryoHandle = mock(Kryo.class);
 
-    private static final String fileName = "test-tickDatabase.dat";
+    private static final String stateFileName = "test-marketState.dat";
+    private static final String snapshotFileName = "test-marketSnapshot.dat";
 
     private static final String GOOD_NAME = "banica";
 
@@ -46,7 +47,7 @@ class SnapshotPersistenceTest {
     @BeforeAll
     static void beforeAll() {
 
-        snapshotPersistence = new SnapshotPersistence(fileName);
+        snapshotPersistence = new SnapshotPersistence(stateFileName, snapshotFileName);
 
     }
 
@@ -54,62 +55,140 @@ class SnapshotPersistenceTest {
     void teardown() throws IOException {
 
         reset(kryoHandle);
-        File testTickDB = ApplicationDirectoryUtil.getConfigFile(fileName);
-        assert testTickDB.delete();
+        File stateFile = ApplicationDirectoryUtil.getConfigFile(stateFileName);
+        File snapshotFile = ApplicationDirectoryUtil.getConfigFile(snapshotFileName);
+        assert stateFile.delete();
+        assert snapshotFile.delete();
 
     }
 
     @Test
-    void persistTicks() throws IOException {
+    void persistMarketState() throws IOException {
 
-        SnapshotPersistence snapshotPersistence = new SnapshotPersistence(fileName);
+        SnapshotPersistence snapshotPersistence = new SnapshotPersistence(stateFileName, snapshotFileName);
+        SnapshotPersistence snapshotPersistenceSpy = spy(snapshotPersistence);
+        ReflectionTestUtils.setField(snapshotPersistenceSpy, "kryoHandle", kryoHandle);
+
+        Map<String, Set<MarketTick>> marketState = new ConcurrentHashMap<>();
+        Map<String, Set<MarketTick>> marketStateSpy = spy(marketState);
+
+        MarketTick marketTick = new MarketTick(GOOD_NAME, 1, 1, 1);
+        Queue<MarketTick> marketSnapshot = new LinkedBlockingQueue<>();
+        marketSnapshot.add(marketTick);
+
+        TreeSet<MarketTick> goodSet = new TreeSet<>();
+        TreeSet<MarketTick> goodSetSpy = spy(goodSet);
+
+        when(marketStateSpy.putIfAbsent(GOOD_NAME, new TreeSet<>())).thenReturn(goodSetSpy);
+        when(marketStateSpy.get(GOOD_NAME)).thenReturn(goodSetSpy);
+
+
+        snapshotPersistenceSpy.persistMarketState(marketStateSpy, marketSnapshot);
+
+
+        verify(marketStateSpy, times(1)).putIfAbsent(GOOD_NAME, new TreeSet<>());
+        verify(marketStateSpy, times(1)).get(GOOD_NAME);
+        verify(goodSetSpy, times(1)).add(marketTick);
+        assertTrue(marketSnapshot.isEmpty());
+
+        verify(kryoHandle, times(1)).writeClassAndObject(any(Output.class), eq(marketStateSpy));
+        verify(snapshotPersistenceSpy, times(1)).persistMarketSnapshot(marketSnapshot);
+
+    }
+
+    @Test
+    void persistMarketSnapshot() throws IOException {
+
+        SnapshotPersistence snapshotPersistence = new SnapshotPersistence(stateFileName, snapshotFileName);
         ReflectionTestUtils.setField(snapshotPersistence, "kryoHandle", kryoHandle);
-        Map<String, Set<MarketTick>> newTicks = new ConcurrentHashMap<>();
-        Map<String, Set<MarketTick>> newTicksSpy = spy(newTicks);
+        Queue<MarketTick> marketSnapshot = new LinkedBlockingQueue<>();
+        Queue<MarketTick> marketSnapshotSpy = spy(marketSnapshot);
 
-        snapshotPersistence.persistTicks(newTicksSpy);
+        snapshotPersistence.persistMarketSnapshot(marketSnapshotSpy);
 
-        verify(kryoHandle, times(1)).writeClassAndObject(any(Output.class), eq(newTicksSpy));
+        verify(kryoHandle, times(1)).writeClassAndObject(any(Output.class), eq(marketSnapshotSpy));
 
     }
 
     @Test
-    void loadPersistedSnapshot_WhenFileDoesNotExist() throws IOException {
+    void loadMarketState_WhenFileDoesNotExist() throws IOException {
 
-        assertFalse(ApplicationDirectoryUtil.doesFileExist(fileName));
+        assertFalse(ApplicationDirectoryUtil.doesFileExist(stateFileName));
 
-        Map<String, Set<MarketTick>> result = snapshotPersistence.loadPersistedSnapshot();
+        Map<String, Set<MarketTick>> result = snapshotPersistence.loadMarketState();
 
-        assertTrue(ApplicationDirectoryUtil.doesFileExist(fileName));
+        assertTrue(ApplicationDirectoryUtil.doesFileExist(stateFileName));
         assertEquals(new ConcurrentHashMap<>(), result);
 
     }
 
     @Test
-    void loadPersistedSnapshot_WhenFileExistsButIsEmpty() throws IOException {
+    void loadMarketState_WhenFileExistsButIsEmpty() throws IOException {
 
-        ApplicationDirectoryUtil.getConfigFile(fileName);
-        assertTrue(ApplicationDirectoryUtil.doesFileExist(fileName));
+        ApplicationDirectoryUtil.getConfigFile(stateFileName);
+        assertTrue(ApplicationDirectoryUtil.doesFileExist(stateFileName));
 
-        Map<String, Set<MarketTick>> result = snapshotPersistence.loadPersistedSnapshot();
+        Map<String, Set<MarketTick>> result = snapshotPersistence.loadMarketState();
 
-        assertTrue(ApplicationDirectoryUtil.doesFileExist(fileName));
+        assertTrue(ApplicationDirectoryUtil.doesFileExist(stateFileName));
         assertEquals(new ConcurrentHashMap<>(), result);
 
     }
 
     @Test
-    void loadPersistedSnapshot_WhenFileExistsAndHasTicks() throws IOException {
+    void loadMarketState_WhenFileExistsAndHasTicks() throws IOException {
 
         Map<String, Set<MarketTick>> expected = new ConcurrentHashMap<>();
         expected.put(GOOD_NAME, new TreeSet<>());
         expected.get(GOOD_NAME).add(new MarketTick(GOOD_NAME, 1, 1, 1));
         expected.get(GOOD_NAME).add(new MarketTick(GOOD_NAME, 2, 2, 2));
-        snapshotPersistence.persistTicks(expected);
+        snapshotPersistence.persistMarketState(expected, new LinkedBlockingQueue<>());
 
-        Map<String, Set<MarketTick>> actual = snapshotPersistence.loadPersistedSnapshot();
+        Map<String, Set<MarketTick>> actual = snapshotPersistence.loadMarketState();
 
         assertEquals(expected, actual);
+
+    }
+
+    @Test
+    void loadMarketSnapshot_WhenFileDoesNotExist() throws IOException {
+
+        assertFalse(ApplicationDirectoryUtil.doesFileExist(snapshotFileName));
+
+        Queue<MarketTick> result = snapshotPersistence.loadMarketSnapshot();
+
+        assertTrue(ApplicationDirectoryUtil.doesFileExist(snapshotFileName));
+        assertTrue(result.isEmpty());
+        assertTrue(result instanceof LinkedBlockingQueue);
+
+    }
+
+    @Test
+    void loadMarketSnapshot_WhenFileExistsButIsEmpty() throws IOException {
+
+        ApplicationDirectoryUtil.getConfigFile(snapshotFileName);
+        assertTrue(ApplicationDirectoryUtil.doesFileExist(snapshotFileName));
+
+        Queue<MarketTick> result = snapshotPersistence.loadMarketSnapshot();
+
+        assertTrue(ApplicationDirectoryUtil.doesFileExist(snapshotFileName));
+        assertTrue(result.isEmpty());
+        assertTrue(result instanceof LinkedBlockingQueue);
+
+    }
+
+    @Test
+    void loadMarketSnapshot_WhenFileExistsAndHasTicks() throws IOException {
+
+        Queue<MarketTick> expected = new LinkedBlockingQueue<>();
+        expected.add(new MarketTick(GOOD_NAME, 1, 1, 1));
+        expected.add(new MarketTick(GOOD_NAME, 2, 2, 2));
+        snapshotPersistence.persistMarketSnapshot(expected);
+
+        Queue<MarketTick> actual = snapshotPersistence.loadMarketSnapshot();
+
+        assertEquals(expected.size(), actual.size());
+        actual.forEach(marketTick -> assertEquals(expected.poll(), marketTick));
 
     }
 


### PR DESCRIPTION
As discussed with Vladimir:
- Updated Snapshot persistence to save into two files.
1. Market state file consists of all historical ticks and is saved according to the set frequency (using JMX or default 60 seconds).
2. Market snapshot file consists of only the ticks that have happened between each market state persistence, the file is saved after every tick so that we don't lose any ticks.

- Updated the tests as well.