### PR TITLE
Updated Market persistence & tests.

### DIFF
--- a/market-generator/src/main/java/com/market/banica/generator/service/MarketState.java
+++ b/market-generator/src/main/java/com/market/banica/generator/service/MarketState.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface MarketState {
 
-    void addTickToMarketSnapshot(MarketTick marketTick);
+    void addTickToMarket(MarketTick marketTick);
 
     List<TickResponse> generateMarketTicks(String good);
 

--- a/market-generator/src/main/java/com/market/banica/generator/service/MarketStateImpl.java
+++ b/market-generator/src/main/java/com/market/banica/generator/service/MarketStateImpl.java
@@ -47,8 +47,8 @@ public class MarketStateImpl implements MarketState {
                            @Value("${tick.market.snapshot.file.name}") String snapshotFileName,
                            MarketSubscriptionManager subscriptionManager) throws IOException {
         snapshotPersistence = new SnapshotPersistence(stateFileName, snapshotFileName);
-        this.marketState = snapshotPersistence.loadMarketState();
         this.marketSnapshot = snapshotPersistence.loadMarketSnapshot();
+        this.marketState = snapshotPersistence.loadMarketState(marketSnapshot);
         this.executorService = Executors.newSingleThreadExecutor();
         this.subscriptionManager = subscriptionManager;
         persistScheduler = new PersistScheduler(marketDataLock, snapshotPersistence, marketState, marketSnapshot);
@@ -56,11 +56,15 @@ public class MarketStateImpl implements MarketState {
     }
 
     @Override
-    public void addTickToMarketSnapshot(MarketTick marketTick) {
+    public void addTickToMarket(MarketTick marketTick) {
         executorService.execute(() -> {
             try {
                 marketDataLock.writeLock().lock();
                 marketSnapshot.add(marketTick);
+
+                String good = marketTick.getGood();
+                marketState.putIfAbsent(good, new TreeSet<>());
+                marketState.get(good).add(marketTick);
 
                 snapshotPersistence.persistMarketSnapshot(marketSnapshot);
 
@@ -79,17 +83,10 @@ public class MarketStateImpl implements MarketState {
         try {
             marketDataLock.readLock().lock();
 
-            List<TickResponse> generatedTicks = marketState.getOrDefault(good, new TreeSet<>()).stream()
+            LOGGER.info("Generating market ticks for {} .", good);
+            return marketState.getOrDefault(good, new TreeSet<>()).stream()
                     .map(this::convertMarketTickToTickResponse)
                     .collect(Collectors.toList());
-
-            marketSnapshot.stream()
-                    .filter(marketTick -> marketTick.getGood().equals(good))
-                    .map(this::convertMarketTickToTickResponse)
-                    .forEach(generatedTicks::add);
-
-            LOGGER.info("Successfully generated market ticks for {} .", good);
-            return generatedTicks;
 
         } finally {
             marketDataLock.readLock().unlock();

--- a/market-generator/src/main/java/com/market/banica/generator/service/TickGeneratorImpl.java
+++ b/market-generator/src/main/java/com/market/banica/generator/service/TickGeneratorImpl.java
@@ -86,7 +86,7 @@ public class TickGeneratorImpl implements TickGenerator {
     @Override
     public void executeTickTask(MarketTick marketTick, TickTask nextTick, long delay) {
 
-        marketState.addTickToMarketSnapshot(marketTick);
+        marketState.addTickToMarket(marketTick);
 
         ScheduledFuture<?> taskScheduledFuture = tickScheduler.schedule(nextTick, delay, TimeUnit.SECONDS);
 

--- a/market-generator/src/test/java/com/market/banica/generator/grpc/MarketTestIT.java
+++ b/market-generator/src/test/java/com/market/banica/generator/grpc/MarketTestIT.java
@@ -94,6 +94,15 @@ public class MarketTestIT {
 
     }
 
+    @AfterEach
+    void tearDown() throws IOException {
+
+        assert ApplicationDirectoryUtil.getConfigFile(marketStateName).delete();
+        assert ApplicationDirectoryUtil.getConfigFile(marketSnapshotName).delete();
+        assert ApplicationDirectoryUtil.getConfigFile(marketPropertiesName).delete();
+
+    }
+
     @AfterAll
     public static void cleanUp() throws IOException {
 

--- a/market-generator/src/test/java/com/market/banica/generator/grpc/MarketTestIT.java
+++ b/market-generator/src/test/java/com/market/banica/generator/grpc/MarketTestIT.java
@@ -1,6 +1,5 @@
 package com.market.banica.generator.grpc;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.market.MarketDataRequest;
 import com.market.MarketServiceGrpc;
 import com.market.TickResponse;
@@ -18,7 +17,6 @@ import io.grpc.testing.GrpcCleanupRule;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,7 +80,6 @@ public class MarketTestIT {
     @BeforeEach
     public void setup() {
 
-        ReflectionTestUtils.setField(marketState,"executorService", MoreExecutors.newDirectExecutorService());
         ReflectionTestUtils.setField(marketState, "marketState", new ConcurrentHashMap<String, Set<MarketTick>>());
         ReflectionTestUtils.setField(marketState, "marketSnapshot", new LinkedBlockingQueue<MarketTick>());
 
@@ -192,7 +189,7 @@ public class MarketTestIT {
                                         .asException());
                                 break;
                             }
-                            MarketTick marketTick = new MarketTick(GOOD, 10, 1.0, new Date().getTime());
+                            MarketTick marketTick = new MarketTick(GOOD, 10, 1.0, new Date().getTime() + i);
                             TickResponse response = TickResponse.newBuilder()
                                     .setOrigin(MarketTick.getOrigin())
                                     .setGoodName(marketTick.getGood())
@@ -218,7 +215,7 @@ public class MarketTestIT {
     private void addExpectedResponses(List<TickResponse> expectedResponses) {
         for (int i = 0; i < 5; i++) {
             MarketTick.setOrigin("AMERICA");
-            MarketTick marketTick = new MarketTick(GOOD, 10, 1.0, new Date().getTime());
+            MarketTick marketTick = new MarketTick(GOOD, 10, 1.0, new Date().getTime() + i);
             marketState.addTickToMarket(marketTick);
 
             TickResponse response = TickResponse.newBuilder()

--- a/market-generator/src/test/java/com/market/banica/generator/grpc/MarketTestIT.java
+++ b/market-generator/src/test/java/com/market/banica/generator/grpc/MarketTestIT.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 @SpringJUnitConfig
 @SpringBootTest(classes = MarketGeneratorApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("testMarketIT")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class MarketTestIT {
 
     @Rule

--- a/market-generator/src/test/java/com/market/banica/generator/service/MarketStateImplTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/service/MarketStateImplTest.java
@@ -18,13 +18,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -101,10 +99,12 @@ class MarketStateImplTest {
         when(marketStateMap.get(GOOD_BANICA)).thenReturn(emptySetSpy);
 
 
-        marketState.addTickToMarketSnapshot(marketTick);
+        marketState.addTickToMarket(marketTick);
 
 
         verify(marketSnapshot, times(1)).add(marketTick);
+        verify(marketStateMap, times(1)).putIfAbsent(GOOD_BANICA, new TreeSet<>());
+        verify(emptySetSpy, times(1)).add(marketTick);
         verify(snapshotPersistence, times(1)).persistMarketSnapshot(marketSnapshot);
         verify(subscriptionManager, times(1))
                 .notifySubscribers(convertMarketTickToTickResponse(marketTick));
@@ -112,40 +112,21 @@ class MarketStateImplTest {
     }
 
     @Test
-    void generateMarketTicks_WhenGoodDoesNotExist() {
-
-        MarketTick marketTick1 = new MarketTick(GOOD_EGGS, 1, 1, 1);
-        MarketTick marketTick2 = new MarketTick(GOOD_EGGS, 2, 2, 2);
-
-        when(marketStateMap.getOrDefault(GOOD_BANICA, new TreeSet<>())).thenReturn(new TreeSet<>());
-        when(marketSnapshot.stream()).thenReturn(Stream.of(marketTick1, marketTick2));
-
-
-        List<TickResponse> result = marketState.generateMarketTicks(GOOD_BANICA);
-
-
-        assertEquals(Collections.emptyList(), result);
-        verify(marketStateMap, times(1)).getOrDefault(GOOD_BANICA, new TreeSet<>());
-        verify(marketSnapshot, times(1)).stream();
-
-    }
-
-    @Test
-    void generateMarketTicks_WhenGoodExists() {
+    void generateMarketTicks() {
 
         MarketTick marketTick1 = new MarketTick(GOOD_BANICA, 1, 1, 1);
         MarketTick marketTick2 = new MarketTick(GOOD_BANICA, 2, 2, 2);
         MarketTick marketTick3 = new MarketTick(GOOD_EGGS, 3, 3, 3);
         MarketTick marketTick4 = new MarketTick(GOOD_BANICA, 4, 4, 4);
 
-        Set<MarketTick> marketTicks = new TreeSet<>(Arrays.asList(marketTick1, marketTick2));
+        Set<MarketTick> marketTicks = new TreeSet<>(Arrays.asList(marketTick1, marketTick2, marketTick3, marketTick4));
 
         when(marketStateMap.getOrDefault(GOOD_BANICA, new TreeSet<>()))
                 .thenReturn(marketTicks);
-        when(marketSnapshot.stream()).thenReturn(Stream.of(marketTick3, marketTick4));
 
         List<TickResponse> actual = Arrays.asList(convertMarketTickToTickResponse(marketTick1),
                 convertMarketTickToTickResponse(marketTick2),
+                convertMarketTickToTickResponse(marketTick3),
                 convertMarketTickToTickResponse(marketTick4));
 
 
@@ -154,7 +135,6 @@ class MarketStateImplTest {
 
         assertEquals(actual, result);
         verify(marketStateMap, times(1)).getOrDefault(GOOD_BANICA, new TreeSet<>());
-        verify(marketSnapshot, times(1)).stream();
 
     }
 

--- a/market-generator/src/test/java/com/market/banica/generator/service/TickGeneratorImplTest.java
+++ b/market-generator/src/test/java/com/market/banica/generator/service/TickGeneratorImplTest.java
@@ -197,7 +197,7 @@ class TickGeneratorImplTest {
         tickGenerator.executeTickTask(marketTick, tickTask, delay);
 
 
-        verify(marketState, times(1)).addTickToMarketSnapshot(marketTick);
+        verify(marketState, times(1)).addTickToMarket(marketTick);
         verify(tickScheduler, times(1)).schedule(tickTask, delay, TimeUnit.SECONDS);
         verify(tickTasks, times(1)).put(GOOD_BANICA, taskScheduledFuture);
 


### PR DESCRIPTION
- Updated name of addTickToMarketSnapshot() to addTickToMarket().
- Updated SnapshotPersistence load both MarketState MarketSnapshot to MarketState to be up to date.
- All of the tick information is stored in Market State, market snapshot is used only for loading ticks that happened if sudden crash of service.